### PR TITLE
Dropping repo connection validation from `vagrant status` as there is…

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -257,15 +257,6 @@ configuration["websites"].each do |service,data|
       puts "\nThe repo for websites => #{service} => domain => #{instance["domain"]} is invalid, it must either be a bitbucket.org or github.com repository.\n\n"
       exit 1
     end
-    # validate repo connection
-    Net::SSH.start(
-      "github.com","git",
-      :host_key => "ssh-rsa",
-      :keys => ["provisioners/.ssh/id_rsa"],
-      #:verbose => :debug
-    ) do |session|
-      #puts session.inspect
-    end
     # validate webroot
     if not "#{instance["webroot"]}" == ""
       if not "#{instance["webroot"]}"[-1,1] == "/"


### PR DESCRIPTION
… no reliable way to accomplish this locally, you need an ssh-agent to do this properly of which we can't reliably do from the host as Windows wouldn't have a definitive ssh-agent(.exe) by default. Look into instead catching the denial of connection more gracefully in the provisioner so that it's clearer in Bamboo (maybe throw an exit code of 1?).