### PR TITLE
Utilize version 0.7.6 of vagrant-digitalocean that I just released, t…

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -650,7 +650,7 @@ Vagrant.configure("2") do |config|
       provider.ipv6 = true
       provider.backups_enabled = true
     end
-    config.vm.synced_folder ".", "/vagrant", type: "rsync"
+    config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync_excludes: ["repositories/apache/*", "repositories/iis/*"]
     config.vm.provision "shell", path: "provisioners/redhat/provision.sh", args: ["test","true","false","true"]
   end
   config.vm.define "#{configuration["company"]["name"]}-test-redhat-mysql" do |config|
@@ -665,7 +665,7 @@ Vagrant.configure("2") do |config|
       provider.ipv6 = true
       provider.backups_enabled = true
     end
-    config.vm.synced_folder ".", "/vagrant", type: "rsync"
+    config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync_excludes: ["repositories/apache/*", "repositories/iis/*"]
     config.vm.provision "shell", path: "provisioners/redhat_mysql/provision.sh", args: ["test"]
   end
 
@@ -682,7 +682,7 @@ Vagrant.configure("2") do |config|
       provider.ipv6 = true
       provider.backups_enabled = true
     end
-    config.vm.synced_folder ".", "/vagrant", type: "rsync"
+    config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync_excludes: ["repositories/apache/*", "repositories/iis/*"]
     config.vm.provision "shell", path: "provisioners/redhat/provision.sh", args: ["qc","true","false","true"]
   end
   config.vm.define "#{configuration["company"]["name"]}-qc-redhat-mysql" do |config|
@@ -697,7 +697,7 @@ Vagrant.configure("2") do |config|
       provider.ipv6 = true
       provider.backups_enabled = true
     end
-    config.vm.synced_folder ".", "/vagrant", type: "rsync"
+    config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync_excludes: ["repositories/apache/*", "repositories/iis/*"]
     config.vm.provision "shell", path: "provisioners/redhat_mysql/provision.sh", args: ["qc"]
   end
 
@@ -714,7 +714,7 @@ Vagrant.configure("2") do |config|
       provider.ipv6 = true
       provider.backups_enabled = true
     end
-    config.vm.synced_folder ".", "/vagrant", type: "rsync"
+    config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync_excludes: ["repositories/apache/*", "repositories/iis/*"]
     config.vm.provision "shell", path: "provisioners/redhat/provision.sh", args: ["production","true","false","true"]
   end
   config.vm.define "#{configuration["company"]["name"]}-production-redhat-mysql" do |config|
@@ -729,7 +729,7 @@ Vagrant.configure("2") do |config|
       provider.ipv6 = true
       provider.backups_enabled = true
     end
-    config.vm.synced_folder ".", "/vagrant", type: "rsync"
+    config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync_excludes: ["repositories/apache/*", "repositories/iis/*"]
     config.vm.provision "shell", path: "provisioners/redhat_mysql/provision.sh", args: ["production"]
   end
 


### PR DESCRIPTION
…o exclude rsyncing the repositories folders. Please note, I kind of screwed up the naming, I went with rsync_excludes, which should really be rsync__excludes per vagrant-google plugin, however, Vagrant docs use rsync__exclude? Please fix this, Seth.