### PR TITLE
Fixes #213: Introduce DigitalOcean private networking interfaces for …

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,1 +1,1 @@
-version: 1.6.1
+version: 1.7.0

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1399,7 +1399,7 @@ Vagrant.configure("2") do |config|
     config.hostmanager.aliases = redhathostsfile
     config.vm.synced_folder ".", "/vagrant", disabled: true
     config.vm.synced_folder ".", "/catapult", type: "nfs"
-    # this takes place of git clones
+    # sym link the git clones for local access
     config.vm.synced_folder "repositories", "/var/www/repositories", type: "nfs"
     config.vm.provision "shell", path: "provisioners/redhat/provision.sh", args: ["dev","#{repo}","#{configuration_user["settings"]["gpg_key"]}","apache","#{configuration_user["settings"]["software_validation"]}"]
   end
@@ -1412,7 +1412,7 @@ Vagrant.configure("2") do |config|
     end
     config.vm.synced_folder ".", "/vagrant", disabled: true
     config.vm.synced_folder ".", "/catapult", type: "nfs"
-    # this takes place of git clones
+    # sym link the git clones for local access
     config.vm.synced_folder "repositories", "/var/www/repositories", type: "nfs"
     config.vm.provision :hostmanager
     config.vm.provision "shell", path: "provisioners/redhat/provision.sh", args: ["dev","#{repo}","#{configuration_user["settings"]["gpg_key"]}","mysql","#{configuration_user["settings"]["software_validation"]}"]
@@ -1444,6 +1444,7 @@ Vagrant.configure("2") do |config|
       provider.region = "nyc3"
       provider.size = "#{configuration["environments"]["test"]["servers"]["redhat_mysql"]["slug"]}"
       provider.ipv6 = true
+      provider.private_networking = true
       provider.backups_enabled = true
     end
     config.vm.synced_folder ".", "/vagrant", disabled: true
@@ -1476,6 +1477,7 @@ Vagrant.configure("2") do |config|
       provider.region = "nyc3"
       provider.size = "#{configuration["environments"]["qc"]["servers"]["redhat_mysql"]["slug"]}"
       provider.ipv6 = true
+      provider.private_networking = true
       provider.backups_enabled = true
     end
     config.vm.synced_folder ".", "/vagrant", disabled: true
@@ -1508,6 +1510,7 @@ Vagrant.configure("2") do |config|
       provider.region = "nyc3"
       provider.size = "#{configuration["environments"]["production"]["servers"]["redhat_mysql"]["slug"]}"
       provider.ipv6 = true
+      provider.private_networking = true
       provider.backups_enabled = true
     end
     config.vm.synced_folder ".", "/vagrant", disabled: true

--- a/provisioners/redhat/modules/iptables.sh
+++ b/provisioners/redhat/modules/iptables.sh
@@ -36,7 +36,7 @@ sudo iptables\
     --jump ACCEPT
 # allow for outbound mail
 sudo iptables\
-    -append OUTPUT\
+    --append OUTPUT\
     --protocol tcp\
     --dport 25\
     --jump ACCEPT

--- a/provisioners/redhat/mysql.sh
+++ b/provisioners/redhat/mysql.sh
@@ -211,7 +211,7 @@ while IFS='' read -r -d '' key; do
             cd "/var/www/repositories/apache/${domain}" && git checkout $(echo "${configuration}" | shyaml get-value environments.${1}.branch) 2>&1 | sed "s/^/\t/"
         else
             if [ -z "${software_dbexist}" ]; then
-                echo -e "\t* workflow is set to ${software_workflow} and this is the ${1} environment, however this is a new website and the database does not exist, performing a database restore"
+                echo -e "\t* workflow is set to ${software_workflow} and this is the ${1} environment, however, the database does not exist. performing a database restore"
             else
                 echo -e "\t* workflow is set to ${software_workflow} and this is the ${1} environment, performing a database restore"
             fi


### PR DESCRIPTION
…the redhat_mysql droplets. This will boost performance and security. This will cascade fine for new Catapult stacks, for existing, the droplet will need to be manually powered off, private networking set, then powered back on. Vagrant statuses thereafter will pickup on the new redhat_mysql private ip addresses and append your configuration appropriately.